### PR TITLE
Add User entity and Database initialization

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -499,8 +499,10 @@ checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -2034,6 +2036,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad8935b44e7c13394a179a438e0cebba0fe08fe01b54f152e29a93b5cf993fd4"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -3697,6 +3700,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 name = "studystudio"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "rusqlite",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3701,6 +3701,7 @@ name = "studystudio"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "dirs 6.0.0",
  "rusqlite",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,5 +22,6 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-rusqlite = "0.33.0"
+rusqlite = { version = "0.33.0", features = ["bundled"] }
+chrono = "0.4.39"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,4 +24,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = { version = "0.33.0", features = ["bundled"] }
 chrono = "0.4.39"
+dirs = "6.0.0"
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,0 +1,2 @@
+pub mod user_commands;
+pub use user_commands::*;

--- a/src-tauri/src/commands/user_commands.rs
+++ b/src-tauri/src/commands/user_commands.rs
@@ -1,0 +1,33 @@
+use tauri::State;
+use crate::{
+    models::user::User,
+    repository::UserRepository,
+    errors::command_errors::CommandError,
+    AppState,
+};
+
+#[tauri::command]
+pub fn create_user(name: String, state: State<AppState>) -> Result<String, CommandError> {
+    let mut user = User::new(name)?;
+    
+    let db_conn = state.db_conn();
+    let conn = db_conn.lock().map_err(|_| CommandError::LockFailed)?;
+
+    UserRepository::create(&conn, &mut user)?;
+
+    Ok(format!("Usuário {} criado com sucesso", user.name))
+}
+
+#[tauri::command]
+pub fn get_active_users_count(state: State<AppState>) -> Result<u32, CommandError> { 
+    let db_conn = state.db_conn();
+    let conn = db_conn.lock().map_err(|_| CommandError::LockFailed)?;
+    Ok(UserRepository::count_active(&conn)?)
+}
+
+#[tauri::command]
+pub fn get_active_user_id(state: State<AppState>) -> Result<Option<u32>, CommandError> {
+    let db_conn = state.db_conn();
+    let conn = db_conn.lock().map_err(|_| CommandError::LockFailed)?;
+    Ok(UserRepository::find_active_id(&conn)?)
+}

--- a/src-tauri/src/errors/command_errors.rs
+++ b/src-tauri/src/errors/command_errors.rs
@@ -1,0 +1,37 @@
+use crate::errors::UserError;
+
+#[derive(Debug, serde::Serialize)]
+pub enum CommandError {
+    Validation(String),
+    Database(String),
+    LockFailed,
+}
+
+impl From<UserError> for CommandError {
+    fn from(e: UserError) -> Self {
+        match e {
+            UserError::InvalidName(msg) => CommandError::Validation(msg), 
+            _ => CommandError::Database(e.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::errors::UserError;
+
+    #[test]
+    fn test_user_error_to_command_error_invalid_name() {
+        let user_error = UserError::InvalidName("Nome inválido".to_string());
+
+        let command_error: CommandError = user_error.into();
+
+        if let CommandError::Validation(msg) = command_error {
+            assert_eq!(msg, "Nome inválido");
+        } else {
+            panic!("Esperado CommandError::Validation");
+        }
+    }
+    
+}

--- a/src-tauri/src/errors/mod.rs
+++ b/src-tauri/src/errors/mod.rs
@@ -1,0 +1,2 @@
+pub mod user_errors;
+pub use user_errors::*;

--- a/src-tauri/src/errors/mod.rs
+++ b/src-tauri/src/errors/mod.rs
@@ -1,2 +1,4 @@
 pub mod user_errors;
 pub use user_errors::*;
+pub mod command_errors;
+pub use command_errors::*;

--- a/src-tauri/src/errors/user_errors.rs
+++ b/src-tauri/src/errors/user_errors.rs
@@ -1,0 +1,54 @@
+use std::fmt;
+
+#[derive(Debug)]
+pub enum UserError {
+  InvalidName(String),
+  InvalidStatus(String),
+  DatabaseError(String),
+}
+
+impl std::error::Error for UserError {}
+
+impl fmt::Display for UserError {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    match self {
+      UserError::InvalidName(msg) => write!(f, "Invalid user name: {}", msg),
+      UserError::InvalidStatus(msg) => write!(f, "Invalid user status: {}", msg),
+      UserError::DatabaseError(msg) => write!(f, "Database error: {}", msg),
+    }
+  }
+}
+
+impl From<rusqlite::Error> for UserError {
+  fn from(value: rusqlite::Error) -> Self {
+    UserError::DatabaseError(value.to_string())
+  }
+}
+
+#[cfg(test)]
+use rusqlite;
+
+#[test]
+fn test_invalid_name_error_display() {
+    let error = UserError::InvalidName("John123".to_string());
+    assert_eq!(format!("{}", error), "Invalid user name: John123");
+}
+
+#[test]
+fn test_invalid_status_error_display() {
+    let error = UserError::InvalidStatus("Banned".to_string());
+    assert_eq!(format!("{}", error), "Invalid user status: Banned");
+}
+
+#[test]
+fn test_database_error_display() {
+    let error = UserError::DatabaseError("Connection failed".to_string());
+    assert_eq!(format!("{}", error), "Database error: Connection failed");
+}
+
+#[test]
+fn test_from_rusqlite_error() {
+    let sqlite_error = rusqlite::Error::InvalidQuery;
+    let user_error: UserError = sqlite_error.into();
+    assert!(matches!(user_error, UserError::DatabaseError(_)));
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,9 +1,52 @@
+use rusqlite::{Connection, Result};
+use std::sync::{Arc, Mutex};
+use std::fs;
+use std::path::PathBuf;
+
+use crate::utils::initialize_database::initialize_database;
+
 pub mod models;
 pub mod errors;
 pub mod repository;
+pub mod commands;
+pub mod utils;
+
+pub struct AppState {
+    pub db_conn: Arc<Mutex<Connection>>
+}
+
+impl AppState {
+    pub fn new(db_path: &str) -> Result<Self, Box<dyn std::error::Error>>{
+      let db_path = PathBuf::from(db_path);
+
+      if let Some(parent) = db_path.parent(){
+        fs::create_dir_all(parent).map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+      }
+
+      let conn = Connection::open(db_path)?;
+
+      initialize_database(&conn)?;
+
+      Ok(Self {
+        db_conn: Arc::new(Mutex::new(conn)),
+      })
+    }
+
+    pub fn db_conn(&self) -> Arc<Mutex<Connection>> {
+      Arc::clone(&self.db_conn)
+    }
+
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    let mut db_path = dirs::config_dir().unwrap_or_else(|| PathBuf::from("."));
+    db_path.push("study-studio");
+    db_path.push("app.db");
+
+    let _app_state = AppState::new(db_path.to_str().unwrap())
+      .expect("Failed to initialize the application state");
+
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![])

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,14 +1,11 @@
-// Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-#[tauri::command]
-fn greet(name: &str) -> String {
-    format!("Hello, {}! You've been greeted from Rust!", name)
-}
+pub mod models;
+pub mod errors;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![greet])
+        .invoke_handler(tauri::generate_handler![])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod models;
 pub mod errors;
+pub mod repository;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -1,0 +1,2 @@
+pub mod user;
+pub use user::*;

--- a/src-tauri/src/models/user.rs
+++ b/src-tauri/src/models/user.rs
@@ -1,0 +1,125 @@
+use chrono::{NaiveDateTime, Utc};
+use std::str::FromStr;
+use crate::errors::user_errors::UserError;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UserStatus {
+  Active,
+  Inactive,
+}
+
+impl UserStatus {
+  pub fn as_str(&self) -> &'static str {
+    match self {
+      UserStatus::Active => "active",
+      UserStatus::Inactive => "inactive",
+    }
+  }
+}
+
+impl FromStr for UserStatus {
+  type Err = UserError;
+
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+      match s.to_lowercase().as_str() {
+          "active" => Ok(UserStatus::Active),
+          "inactive" => Ok(UserStatus::Inactive),
+          _ => Err(UserError::InvalidStatus(s.to_string())),
+      }
+  }
+}
+
+impl std::fmt::Display for UserStatus {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+      write!(f, "{}", self.as_str())
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct User {
+  pub id: Option<u32>,
+  pub name: String,
+  pub status: UserStatus,
+  pub created_at: NaiveDateTime,
+}
+
+impl User {
+  pub fn new(name: String) -> Result<Self, UserError> {
+    if name.trim().is_empty() {
+      return Err(UserError::InvalidName("Name cannot be empty".to_string()));
+    }
+    Ok(User {
+      id: None,
+      name,
+      status: UserStatus::Active,
+      created_at: Utc::now().naive_utc(),
+    })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_user_status_as_str() {
+        let active_status = UserStatus::Active;
+        let inactive_status = UserStatus::Inactive;
+
+        assert_eq!(active_status.as_str(), "active");
+        assert_eq!(inactive_status.as_str(), "inactive");
+    }
+
+    #[test]
+    fn test_user_status_from_str() {
+        let active_status: Result<UserStatus, _> = "active".parse();
+        assert_eq!(active_status.unwrap(), UserStatus::Active);
+
+        let inactive_status: Result<UserStatus, _> = "inactive".parse();
+        assert_eq!(inactive_status.unwrap(), UserStatus::Inactive);
+
+        let invalid_status: Result<UserStatus, _> = "unknown".parse();
+        assert!(invalid_status.is_err());
+    }
+
+    #[test]
+    fn test_user_status_display() {
+        let active_status = UserStatus::Active;
+        let inactive_status = UserStatus::Inactive;
+
+        assert_eq!(format!("{}", active_status), "active");
+        assert_eq!(format!("{}", inactive_status), "inactive");
+    }
+
+    #[test]
+    fn test_create_user_with_valid_name() {
+        let user_name = "Alice".to_string();
+        let user = User::new(user_name.clone());
+
+        assert!(user.is_ok());
+        let user = user.unwrap();
+        assert_eq!(user.name, user_name);
+        assert_eq!(user.status, UserStatus::Active);
+    }
+
+    #[test]
+    fn test_create_user_with_empty_name() {
+        let user_name = "".to_string();
+        let user = User::new(user_name);
+
+        assert!(user.is_err());
+        if let Err(UserError::InvalidName(msg)) = user {
+            assert_eq!(msg, "Name cannot be empty");
+        } else {
+            panic!("Expected InvalidName error");
+        }
+    }
+
+    #[test]
+    fn test_user_creation_has_valid_timestamp() {
+        let user = User::new("Bob".to_string()).unwrap();
+        let current_time = Utc::now().naive_utc();
+
+        assert!(user.created_at <= current_time);
+    }
+}

--- a/src-tauri/src/repository/mod.rs
+++ b/src-tauri/src/repository/mod.rs
@@ -1,0 +1,117 @@
+use rusqlite::{Connection, params};
+use crate::{models::User, errors::UserError};
+
+pub struct UserRepository;
+
+impl UserRepository {
+    pub fn create(conn: &Connection, user: &mut User) -> Result<(), UserError> {
+        conn.execute(
+            "INSERT INTO users (name, status, created_at) VALUES (?1, ?2, ?3)",
+            params![user.name, user.status.to_string(), user.created_at.format("%Y-%m-%d %H:%M:%S").to_string()],
+        )
+        .map_err(|e| UserError::DatabaseError(e.to_string()))?;
+
+        user.id = Some(conn.last_insert_rowid() as u32);
+        Ok(())
+    }
+
+    pub fn count_active(conn: &Connection) -> Result<u32, UserError> {
+        let mut stmt = conn
+            .prepare("SELECT COUNT(*) FROM users WHERE status = 'active'")
+            .map_err(|e| UserError::DatabaseError(e.to_string()))?;
+
+        let count: u32 = stmt
+            .query_row([], |row| row.get(0))
+            .map_err(|e| UserError::DatabaseError(e.to_string()))?;
+
+        Ok(count)
+    }
+
+    pub fn find_active_id(conn: &Connection) -> Result<Option<u32>, UserError> {
+        let mut stmt = conn
+            .prepare("SELECT id FROM users WHERE status = 'active' LIMIT 1")
+            .map_err(|e| UserError::DatabaseError(e.to_string()))?;
+
+        let mut rows = stmt
+            .query([])
+            .map_err(|e| UserError::DatabaseError(e.to_string()))?;
+
+        if let Some(row) = rows.next()? {
+            Ok(Some(row.get(0)?))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+    use chrono::{Utc, NaiveDateTime};
+    use crate::models::UserStatus;
+    use std::str::FromStr;
+
+    fn setup_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute(
+            "CREATE TABLE users (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            )",
+            [],
+        ).unwrap();
+        conn
+    }
+
+    #[test]
+    fn test_create_user() {
+        let conn = setup_db();
+        let mut user = User::new("Alice".to_string()).unwrap();
+        assert!(UserRepository::create(&conn, &mut user).is_ok());
+        assert!(user.id.is_some());
+
+        let saved_user: User = conn.query_row(
+            "SELECT id, name, status, created_at FROM users WHERE id = ?",
+            [user.id.unwrap()],
+            |row| Ok(User {
+                id: Some(row.get(0)?),
+                name: row.get(1)?,
+                status: UserStatus::from_str(&row.get::<_, String>(2)?).unwrap(),
+                created_at: NaiveDateTime::parse_from_str(&row.get::<_, String>(3)?, "%Y-%m-%d %H:%M:%S").unwrap(), // Coluna 3: created_at (TEXT)
+            })
+        ).unwrap();
+
+        assert_eq!(saved_user.name, "Alice");
+        assert_eq!(saved_user.status, UserStatus::Active);
+    }
+
+    #[test]
+    fn test_count_active() {
+        let conn = setup_db();
+        let mut user1 = User::new("Alice".to_string()).unwrap();
+        UserRepository::create(&conn, &mut user1).unwrap();
+        
+        let mut user2 = User { 
+            id: None, 
+            name: "Inactive".to_string(), 
+            status: UserStatus::Inactive, 
+            created_at: Utc::now().naive_utc() 
+        };
+        UserRepository::create(&conn, &mut user2).unwrap();
+
+        assert_eq!(UserRepository::count_active(&conn).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_find_active_id() {
+        let conn = setup_db();
+        assert!(UserRepository::find_active_id(&conn).unwrap().is_none());
+
+        let mut user = User::new("Alice".to_string()).unwrap();
+        UserRepository::create(&conn, &mut user).unwrap();
+        assert_eq!(UserRepository::find_active_id(&conn).unwrap(), Some(user.id.unwrap()));
+    }
+}

--- a/src-tauri/src/utils/initialize_database.rs
+++ b/src-tauri/src/utils/initialize_database.rs
@@ -1,0 +1,40 @@
+use rusqlite::{Connection, Result};
+
+pub fn initialize_database(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            status TEXT CHECK(status IN ('active', 'inactive')) NOT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL
+        );
+        
+        CREATE TABLE IF NOT EXISTS user_logins (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            login DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        );
+
+        CREATE TABLE IF NOT EXISTS tags (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tag_name TEXT NOT NULL,
+            tag_color TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS tasks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            description TEXT,
+            status TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            due_date TEXT NOT NULL,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        );
+        "#
+    )?;
+    Ok(())
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,0 +1,2 @@
+pub mod initialize_database;
+pub use initialize_database::initialize_database;


### PR DESCRIPTION
# Add User entity and Database initialization


## Description:
This PR introduces the initial database setup using SQLite with `rusqlite` and implements the `UserRepository` with essential methods for user management. Additionally, it includes custom errors for the repository layer and command handlers to interact with the user data.

### **Changes:**
- Initialized SQLite database using `rusqlite`.
- Created `User` model with essential fields.
- Implemented `UserRepository` with the following methods:
  - `create(user: &User) -> Result<()>`
  - `count_active_users() -> Result<u32>`
  - `find_active_by_id(id: i32) -> Result<Option<User>>`
- Added custom errors for the `UserRepository` to handle database operations gracefully.
- Introduced commands in Tauri to expose repository methods to the frontend.

### **Why this is needed:**
This feature provides the foundation for user management in the application. The repository ensures a clean separation between database operations and business logic while enabling efficient user querying.

### Running Tests in Tauri (Rust)

To run tests in the `src-tauri` folder, follow these steps.

## Run All Tests
Navigate to the `src-tauri` directory and execute:
```sh
cd src-tauri
cargo test
```



